### PR TITLE
Add unit tests for Header component

### DIFF
--- a/src/components/header/Header.test.tsx
+++ b/src/components/header/Header.test.tsx
@@ -1,0 +1,172 @@
+import type { SVGProps } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Header from "./Header";
+import { useAuth } from "../../auth/useAuth";
+import { signOut } from "firebase/auth";
+import type { User } from "firebase/auth";
+
+const mockUser = {
+  uid: "123",
+  email: "anna@test.com",
+} as User;
+
+vi.mock("../../auth/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("firebase/auth", () => ({
+  signOut: vi.fn(),
+}));
+
+vi.mock("../../lib/firebase/firebase", () => ({
+  auth: { app: "mock-auth" },
+}));
+
+vi.mock("../../assets/watching-cat.svg?react", () => ({
+  default: (props: SVGProps<SVGSVGElement>) => (
+    <svg data-testid="watching-cat" {...props} />
+  ),
+}));
+
+vi.mock("./HeaderBrand", () => ({
+  default: () => <div data-testid="header-brand">HeaderBrand</div>,
+}));
+
+vi.mock("./HeaderNavLinks", () => ({
+  default: ({
+    links,
+    className,
+  }: {
+    links: Array<{ to: string; label: string }>;
+    className?: string;
+  }) => (
+    <div data-testid="header-nav-links" className={className}>
+      {links.map((link) => (
+        <span key={link.to}>{link.label}</span>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("./HeaderUserMenu", () => ({
+  default: ({
+    isOpen,
+    setIsOpen,
+    onLogout,
+  }: {
+    isOpen: boolean;
+    setIsOpen: (value: boolean | ((prev: boolean) => boolean)) => void;
+    onLogout: () => Promise<void>;
+  }) => (
+    <div data-testid="header-user-menu">
+      <button type="button" onClick={() => setIsOpen((prev) => !prev)}>
+        Toggle user menu
+      </button>
+      <div>{isOpen ? "User menu open" : "User menu closed"}</div>
+      <button type="button" onClick={onLogout}>
+        User menu sign out
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("./HeaderMobileMenu", () => ({
+  default: ({
+    isOpen,
+    isAuthed,
+    onLogout,
+  }: {
+    isOpen: boolean;
+    isAuthed: boolean;
+    onLogout: () => Promise<void>;
+  }) => (
+    <div data-testid="header-mobile-menu">
+      <div>{isOpen ? "Mobile menu open" : "Mobile menu closed"}</div>
+      <div>{isAuthed ? "Authed mobile menu" : "Guest mobile menu"}</div>
+      <button type="button" onClick={onLogout}>
+        Mobile logout
+      </button>
+    </div>
+  ),
+}));
+
+describe("Header", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading text when auth is loading", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      loading: true,
+    });
+
+    render(<Header />);
+
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+
+  it("shows desktop Sign out button for authenticated user", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: mockUser,
+      loading: false,
+    });
+
+    render(<Header />);
+
+    expect(
+      screen.getByRole("button", { name: /^sign out$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show desktop Sign out button for guest user", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      loading: false,
+    });
+
+    render(<Header />);
+
+    expect(
+      screen.queryByRole("button", { name: /^sign out$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls firebase signOut when desktop Sign out is clicked", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: mockUser,
+      loading: false,
+    });
+
+    vi.mocked(signOut).mockResolvedValue(undefined);
+
+    render(<Header />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^sign out$/i }));
+
+    await waitFor(() => {
+      expect(signOut).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("opens mobile menu when burger button is clicked", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      loading: false,
+    });
+
+    render(<Header />);
+
+    const menuButton = screen.getByRole("button", { name: /open main menu/i });
+
+    expect(menuButton).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByText("Mobile menu closed")).toBeInTheDocument();
+
+    fireEvent.click(menuButton);
+
+    expect(menuButton).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Mobile menu open")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Add unit tests for Header component

## Overview
This PR adds unit tests for the **Header** component as part of the **Week 4 checkpoint**.

The purpose of these tests is to verify the main behaviors of the Header related to authentication state and user interaction.

## What was added

A new test file:
The tests are written using **Vitest** and **React Testing Library**.

## Tests implemented

Five test cases were added:

1. **Loading state**
   - Verifies that the Header shows the `Loading…` text while authentication state is being resolved.

2. **Authenticated user UI**
   - Ensures that the **Sign out** button appears when a user is logged in.

3. **Guest user UI**
   - Confirms that the **Sign out** button is not rendered for unauthenticated users.

4. **Logout behavior**
   - Checks that clicking the **Sign out** button triggers the Firebase `signOut` function.

5. **Mobile menu interaction**
   - Verifies that the mobile navigation menu toggles when the burger menu button is clicked.

## Testing approach

To isolate the Header logic:

- Firebase authentication was **mocked**
- the `useAuth` hook was **mocked**
- child components (`HeaderBrand`, `HeaderUserMenu`, `HeaderNavLinks`, `HeaderMobileMenu`) were **mocked**

This ensures the tests focus only on **Header behavior** rather than the implementation of nested components.

## Tools used

- Vitest
- React Testing Library

## Result

These tests validate key behaviors of the Header component:

- authentication state rendering
- logout interaction
- responsive navigation behavior

### Screenshot 
<img width="487" height="260" alt="Screenshot 2026-03-16 at 11 41 34" src="https://github.com/user-attachments/assets/d5fecd4a-8ed5-4c12-ae97-6474e4d578f4" />

